### PR TITLE
Feature 407 adding analytics for document feedback

### DIFF
--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -1,6 +1,10 @@
-<button class="sgds-button js-thumbs-up">
-    <span class="sgds-icon sgds-icon-thumbs-up is-size-4" title="thumbs-up" alt="thumbs-up" role="img" aria-label="thumbs-up"></span>
-</button>
-<button class="sgds-button js-thumbs-down">
-    <span class="sgds-icon sgds-icon-thumbs-down is-size-4" title="thumbs-down" alt="thumbs-down" role="img" aria-label="thumbs-down"></span>
-</button>
+<div id="feedback" class="row is-hidden">
+    <div class="col is-12">
+        <button class="sgds-button js-thumbs-up">
+            <span class="sgds-icon sgds-icon-thumbs-up is-size-4" title="thumbs-up" alt="thumbs-up" role="img" aria-label="thumbs-up"></span>
+        </button>
+        <button class="sgds-button js-thumbs-down">
+            <span class="sgds-icon sgds-icon-thumbs-down is-size-4" title="thumbs-down" alt="thumbs-down" role="img" aria-label="thumbs-down"></span>
+        </button>
+    </div>
+</div>

--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -1,0 +1,6 @@
+<button class="sgds-button js-thumbs-up">
+    <span class="sgds-icon sgds-icon-thumbs-up is-size-4" title="thumbs-up" alt="thumbs-up" role="img" aria-label="thumbs-up"></span>
+</button>
+<button class="sgds-button js-thumbs-down">
+    <span class="sgds-icon sgds-icon-thumbs-down is-size-4" title="thumbs-down" alt="thumbs-down" role="img" aria-label="thumbs-down"></span>
+</button>

--- a/_layouts/layout-page-sidenav.html
+++ b/_layouts/layout-page-sidenav.html
@@ -12,6 +12,7 @@ layout: layout-page
   </div>
   <div class="col is-9 is-12-touch">
     {{ content }}
+    {%- include feedback.html -%}
     <p>
       <em>
         Last updated {{ page.last_modified_at | date: '%d %B %Y' }}

--- a/apps/src/lib/config.js
+++ b/apps/src/lib/config.js
@@ -1,4 +1,5 @@
 export default {
   nodeEnv: process.env.NODE_ENV,
   apiUrl: process.env.API_URL,
+  gaId: process.env.GA_ID,
 };

--- a/apps/src/main.js
+++ b/apps/src/main.js
@@ -1,5 +1,6 @@
 import "./main.scss";
 import "sgds-govtech/js/sgds.js";
+import config from "./lib/config";
 
 $(function() {
   $(".mobile-sidenav-toggle").click(function() {
@@ -14,5 +15,34 @@ $(function() {
     $(this)
       .next()
       .toggleClass("is-hidden-touch");
+  });
+
+  // GA-12345 -> GA_12345 for consistency with GAID set by GA on startup
+  const gaId= config.gaId.replace(/-/g, '_');
+  const eventCategory = 'Test Feedback';
+
+  // Enable feedback feature
+  if (localStorage.getItem('enableFeedback') === '1' ) {
+    $('#feedback').removeClass('is-hidden');
+  }
+
+  $(".js-thumbs-up").click(function() {
+    ga(`gtag_${gaId}.send`, {
+      hitType: 'event',
+      eventCategory: eventCategory,
+      eventAction: 'thumbs-up',
+      eventLabel: 'thumbs-up-icon',
+      eventValue: 1
+    });
+  });
+
+  $("js-thumbs-down").click(function() {
+    ga(`gtag_${gaId}.send`, {
+      hitType: 'event',
+      eventCategory: eventCategory,
+      eventAction: 'thumbs-down',
+      eventLabel: 'thumbs-down-icon',
+      eventValue: 0
+    });
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,7 @@ module.exports = (env, argv) => {
           argv.mode === "production"
             ? "https://api.developer.gov.sg/v1/api"
             : process.env.API_URL,
+        GA_ID: process.env.GA_ID || null
       }),
     ],
   };


### PR DESCRIPTION
- Added a thumbs up/down feedback component and utilising google analytics to send events
![image](https://user-images.githubusercontent.com/2618932/125218086-bdd9d780-e2f4-11eb-9d67-e75e663307eb.png)

- New segments are setup in GA to track the events
![image](https://user-images.githubusercontent.com/2618932/125218237-0ee9cb80-e2f5-11eb-9bb1-7847c6ebfea9.png)

The feature is disabled by default. It can be enabled by setting the localStorage key value of `enableFeedback` to `1`

