### PR TITLE
Fix feedback modal on modal

### DIFF
--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -28,7 +28,7 @@
     </div>
     <!-- Modal that shows page is useful -->
     <div
-      class="sgds-modal js-feedback-useful-modal"
+      class="sgds-modal is-fullwidth is-maxmediumwidth js-feedback-useful-modal"
       id="feedback-modal-useful-yes"
       aria-labelledby="developer portal feedback"
       role="dialog"
@@ -37,9 +37,9 @@
 
       <div class="sgds-modal-card">
         <header class="sgds-modal-card-head">
-          <p class="sgds-modal-card-title" id="sgds-modal-title">
+          <div class="sgds-modal-card-title" id="sgds-modal-title">
             Did this page help you? - Yes
-          </p>
+          </div>
           <button class="delete js-close-feedback-modal" aria-label="close"></button>
         </header>
         <section class="sgds-modal-card-body">
@@ -63,7 +63,7 @@
 
     <!-- Modal that shows page needs improvement -->
     <div
-      class="sgds-modal js-feedback-useful-modal"
+      class="sgds-modal is-fullwidth js-feedback-useful-modal"
       id="feedback-modal-useful-no"
       aria-labelledby="developer portal feedback"
       role="dialog"

--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -33,7 +33,7 @@
       aria-labelledby="developer portal feedback"
       role="dialog"
     >
-      <div class="sgds-modal-background"></div>
+      <div class="sgds-modal-background js-close-feedback-modal"></div>
 
       <div class="sgds-modal-card">
         <header class="sgds-modal-card-head">
@@ -68,7 +68,7 @@
       aria-labelledby="developer portal feedback"
       role="dialog"
     >
-      <div class="sgds-modal-background"></div>
+      <div class="sgds-modal-background js-close-feedback-modal"></div>
 
       <div class="sgds-modal-card">
         <header class="sgds-modal-card-head">

--- a/apps/src/main.scss
+++ b/apps/src/main.scss
@@ -158,6 +158,15 @@ a.external-link::after {
 .idea-sprint-poster {
   max-width: 45%;
 }
+
+.sgds-modal .sgds-modal-card-title {
+  flex-shrink: 1;
+}
+
+.sgds-modal.is-maxmediumwidth .sgds-modal-card {
+  max-width: 600px;
+}
+
 @media screen and (max-width: 1215px) {
   .idea-sprint-poster {
     max-width: 60%;


### PR DESCRIPTION
- Fix feedback modal does not display correctly for mobile
![image](https://user-images.githubusercontent.com/2618932/126600443-31155a72-57f1-4f53-b3fd-0f3f47a284aa.png)
- enable user to close the modal when the modal background is clicked
