### PR TITLE
Included missing hyperlink for onboarding instructions

### DIFF
--- a/collections/_technologies/data-and-apis/apex.md
+++ b/collections/_technologies/data-and-apis/apex.md
@@ -104,7 +104,7 @@ As a consumer, users can follow the steps below to begin their APEX onboarding.
 
 **Step 1 - Getting Access from the Provider**
 
-Consumers visit this site (only accessible through Intranet) to identify the required APIs before requesting access from the Provider.  Consumers can also sign up for the training session provided by the APEX team to understand how APPs can be created in APEX.
+Consumers visit this [site](https://portal.apex.gov.sg/catalogue/highlights) {:target="_blank"}(only accessible through Intranet) to identify the required APIs before requesting access from the Provider.  Consumers can also sign up for the training session provided by the APEX team to understand how APPs can be created in APEX.
 
 **Step 2 - Opening of Firewalls**
 


### PR DESCRIPTION
For step 1 of the onboarding of APEX consumers, there is a missing hyperlink for the phrase "this site" in this sentence "Consumers visit this site (only accessible through Intranet) to identify the required APIs before requesting access from the Provider. "

The hyperlink has been added