### PR TITLE
Stack x cloud 2021 updates (do not delete)

### DIFF
--- a/_data/stackx2021cloud.yml
+++ b/_data/stackx2021cloud.yml
@@ -225,7 +225,7 @@
 - type: Government
   timeslot: 1:30 PM - 1:50 PM
   title: What's New in GCC 2.0
-  desc: GCC 2.0 represents a refinement from our initial platform, based on feedback and learnings over the past two yesrs. This session will introduce some of the new features and capabilities that will enable a more cloud native environment for applications.
+  desc: GCC 2.0 represents a refinement from our initial platform, based on feedback and learning points over the past two yesrs. This session will introduce some of the new features and capabilities that will enable a more cloud native environment for applications.
   speakers: 
     - name: Hunter Nield
       image: /assets/img/stack-x-cloud-2021-hunter-nield.png

--- a/_data/stackx2021cloud.yml
+++ b/_data/stackx2021cloud.yml
@@ -225,7 +225,7 @@
 - type: Government
   timeslot: 1:30 PM - 1:50 PM
   title: What's New in GCC 2.0
-  desc: 
+  desc: GCC 2.0 represents a refinement from our initial platform, based on feedback and learnings over the past two yesrs. This session will introduce some of the new features and capabilities that will enable a more cloud native environment for applications.
   speakers: 
     - name: Hunter Nield
       image: /assets/img/stack-x-cloud-2021-hunter-nield.png

--- a/_data/stackx2021cloud.yml
+++ b/_data/stackx2021cloud.yml
@@ -225,7 +225,7 @@
 - type: Government
   timeslot: 1:30 PM - 1:50 PM
   title: What's New in GCC 2.0
-  desc: GCC 2.0 represents a refinement from our initial platform, based on feedback and learning points over the past two yesrs. This session will introduce some of the new features and capabilities that will enable a more cloud native environment for applications.
+  desc: GCC 2.0 represents a refinement from our initial platform, based on feedback and learning points over the past two years. This session will introduce some of the new features and capabilities that will enable a more cloud native environment for applications.
   speakers: 
     - name: Hunter Nield
       image: /assets/img/stack-x-cloud-2021-hunter-nield.png

--- a/_data/stackx2021cloud.yml
+++ b/_data/stackx2021cloud.yml
@@ -22,7 +22,7 @@
 
 - type: Keynote
   timeslot: 09:40 AM - 10:10 AM
-  title: Impacts and Lessons Learned from NASA/Jet Propulsion Laboratory's Cloud Computing Journey
+  title: Impact and Lessons Learned from NASA/Jet Propulsion Laboratory's Cloud Computing Journey
   desc: Tom Soderstrom, an industry leader in cloud, shares how NASA embarked on its cloud journey and excelled.
   speakers:
     - name: Tom Soderstrom

--- a/collections/_communities/events/stack-x-cloud-2021.html
+++ b/collections/_communities/events/stack-x-cloud-2021.html
@@ -181,7 +181,7 @@ description: >
 <div class="tab-content" id="tab2">
   <h6>Leadership Track</h6>
   <p><strong>17 November 2021</strong></p>
-  <p>Virtual Conference: Zoom Webinar</p>
+  <p>Virtual Conference: Zoom Meeting</p>
   <p>
     This is a closed virtual track curated for Agency CIOs and IT
     Leaders to help them build and achieve a successful cloud strategy.


### PR DESCRIPTION
slight edits to tom's session title and Hunter's session description. Changed leadership track to zoom meeting.