### PR TITLE
Adding Stack X Cloud 2021 videos

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ timezone: Asia/Singapore
 title: Singapore Government Developer Portal
 description: >
   The Singapore Government Developer Portal is a one-stop resource hub for Government digital services and products.
-url: "https://www.developer.tech.gov.sg" # Need to disable this to have jekyll-redirect-from not obey site.url
+# url: "https://www.developer.tech.gov.sg" # Need to disable this to have jekyll-redirect-from not obey site.url
 logo: /assets/img/logo_developer.gov.sg.png
 search_placeholder: Search
 

--- a/_data/stack-x-cloud-2021-videos.yml
+++ b/_data/stack-x-cloud-2021-videos.yml
@@ -87,7 +87,7 @@
   title: >-
     Enabling Applications to Support Authentication with Azure AD and
     Conditional Access
-  video_id: lQJVeiZmd0
+  video_id: _lQJVeiZmd0
 - type: CloudPlatform - VOD
   speakers: Marco Genovese
   speakers_title: 'Cloud Security Specialist, Google Cloud Security'
@@ -97,4 +97,4 @@
   speakers: Samuel Loh
   speakers_title: 'Senior Software Engineer, Engineering Productivity, GovTech'
   title: Securing Access to GCC 2.0 from Engineering Devices
-  video_id: PONKfE9qeo
+  video_id: PONKfE9q_eo

--- a/_data/stack-x-cloud-2021-videos.yml
+++ b/_data/stack-x-cloud-2021-videos.yml
@@ -1,0 +1,100 @@
+# - type: Video Types
+#   speakers: Speakers in the video. Split by ", "
+#     📢 Please make sure that the speakers name is in the same sequence as speakers title 📢
+#   speakers_title: Speakers' title in the video. Split by "| "
+#   title: Video title
+#   article_link: Slide - article link after the speakers titles'
+#   video_id: Video Id - watch video button
+#   slide_link: Slide - view slide button
+#   Reference: https://docs.google.com/spreadsheets/d/1szkJAWTP0GZCNjZAxQobBAUsor_4URaqheqH70r5BZI/edit#gid=0
+#   Export the data from this excel into a csv file to be converted to a YAML data file
+
+- type: Keynote - VOD
+  speakers: Dr Janil Puthucheary
+  speakers_title: >-
+    Senior Minister of State at Ministry of Communications & Information and
+    Ministry of Health, and Minister-in-Charge of GovTech
+  title: Welcome Remarks
+  video_id: 3Wztk782Sgc
+- type: Keynote - VOD
+  speakers: Tom Soderstrom
+  speakers_title: >-
+    Director of Chief Technologists, Worldwide Public Sector, Amazon Web
+    Services
+  title: >-
+    Impact and Lessons Learned from NASA/Jet Propulsion Laboratory's Cloud
+    Computing Journey
+  video_id: Bl2dcc0yEu4
+- type: Keynote - VOD
+  speakers: Tan Eng Pheng
+  speakers_title: 'Assistant Chief Executive (Services), GovTech'
+  title: Accelerating Digital Transformation with Government on Commercial Cloud
+  video_id: WSRfq88_JvY
+- type: Keynote - VOD
+  speakers: Kevin Ng
+  speakers_title: >-
+    Director, Core Operations Development Environment and eXchange (CODEX),
+    GovTech
+  title: GCC Road Ahead
+  video_id: OKtNwnbWQBQ
+- type: Keynote - VOD
+  speakers: 'Hunter Nield, Chia Hsiao Ming'
+  speakers_title: 'Distinguished Engineer, GovTech| Director, Engineering Productivity, GovTech'
+  title: GCC 2.0 Design Principles and Showcase
+  video_id: FriAm2BnqqA
+- type: CloudOnboarding - VOD
+  speakers: Abhijeet Menon
+  speakers_title: 'Senior Solution Architect, Solution Architect Office, GovTech'
+  title: Building a Successful Cloud Architecture
+  video_id: gq1uwDJ8OhM
+- type: CloudOnboarding - VOD
+  speakers: 'Tang Bing Wan, Jessica Tan'
+  speakers_title: >-
+    Principal Application Infrastructure Architect, Central Technical Services,
+    GovTech| Programme Manager, Core Operations Development Environment and
+    eXchange (CODEX), GovTech
+  title: GCC 2.0 - New Onboarding Experience
+  video_id: cftM662--Cs
+- type: CloudOnboarding - VOD
+  speakers: 'Kent Lai, Mahesh Rajagopal'
+  speakers_title: >-
+    Lead Solution Architect, Solution Architect Office, GovTech| Senior
+    Application Infrastructure Engineer, Central Technical Services, GovTech
+  title: >-
+    Managing Cloud Cost and Security through Automation and Data-Centric
+    Approach
+  video_id: MCV0auno9Cs
+- type: CloudOnboarding - VOD
+  speakers: Choong Keng Leong
+  speakers_title: 'Director, Government Infrastructure Group, GovTech'
+  title: Learning Points from Cloud Operations
+  video_id: tdZt4ZigpFw
+- type: CloudPlatform - VOD
+  speakers: Hunter Nield
+  speakers_title: 'Distinguished Engineer, GovTech'
+  title: What's New in GCC 2.0
+  video_id: KK7dVjQ4LNQ
+- type: CloudPlatform - VOD
+  speakers: 'Stephanie Quek, Yin Yide'
+  speakers_title: >-
+    Lead Cybersecurity Specialist, Cyber Security Group, GovTech| Associate
+    Cybersecurity Specialist, Cyber Security Group, GovTech
+  title: Securing Developers' Engineering Devices
+  video_id: 3M9n5eT8u24
+- type: CloudPlatform - VOD
+  speakers: Kyle Marsh
+  speakers_title: 'Principal Programme Manager, Microsoft'
+  title: >-
+    Enabling Applications to Support Authentication with Azure AD and
+    Conditional Access
+  video_id: lQJVeiZmd0
+- type: CloudPlatform - VOD
+  speakers: Marco Genovese
+  speakers_title: 'Cloud Security Specialist, Google Cloud Security'
+  title: 'Zero Trust: The Future of Secure Remote Access'
+  video_id: I5dpXijcPgU
+- type: CloudPlatform - VOD
+  speakers: Samuel Loh
+  speakers_title: 'Senior Software Engineer, Engineering Productivity, GovTech'
+  title: Securing Access to GCC 2.0 from Engineering Devices
+  video_id: PONKfE9qeo

--- a/collections/_communities/events/stack-x-cloud-2021-video-list.html
+++ b/collections/_communities/events/stack-x-cloud-2021-video-list.html
@@ -1,0 +1,65 @@
+<div class="card-grid-container is-fullwidth">
+    {% comment %}
+    {% assign videos = site.data.stack-x-cloud-2021-videos | where: include.type %}
+    {% endcomment %}
+    {% assign video_types = include.type | split: ", " %}
+    <!-- TODO: abstract out the place to get the videos -->
+    {% assign videos = site.data.stack-x-cloud-2021-videos | where_exp: "video", "video_types contains video.type" %}
+    {% for video in videos %}
+    {% assign video_id = video.video_id %}
+    {% assign video_url = "https://www.youtube.com/watch?v=" | append: video_id %}
+    {% assign video_title = video.title %}
+    {% assign speakers = video.speakers | split: ", " %}
+    {% assign speakers_title = video.speakers_title | split: "| " %}
+    {% assign article_link = video.article_link %}
+    {% assign slide_link = video.slide_link %}
+    {% assign video_image = "https://img.youtube.com/vi/$video_id/hqdefault.jpg" | replace: "$video_id", video_id %}
+
+    <div class="sgds-card sgds-card-variant-video-info">
+      <div class="sgds-card-content">
+        <div class="content-grid">
+          {% if video_id != nil %}
+          <div class="sgds-card-image">
+            <figure class="sgds-image">
+              <a href="{{ video_url }}">
+                <img alt="stack 2020 video thumbnail" src="{{ video_image }}" />
+              </a>
+            </figure>
+          </div>
+          {% else %}
+            <!-- TODO: abstract out the folder reference -->
+            <img alt="stack 2020 video thumbnail" src="/assets/img/stack-2020/stack-2020-video.png" />
+          {% endif %}
+          <div class="info">
+            {% if video_id != nil %}
+            <h4>
+              <a href="{{ video_url }}" target="_blank" rel="noopener noreferrer">
+                {{ video_title }}
+              </a>
+            </h4>
+            {% else %}
+              <h4>{{ video_title }}</h4>
+            {% endif %}
+            <p>
+              <strong>Speaker(s)</strong> <br>
+              {% for speaker in speakers %}
+              {% assign speaker_index = forloop.index| minus: 1 %}
+              <strong>{{ speaker }}</strong>, {{speakers_title[speaker_index]}}<br><br>
+              {% endfor %}
+            </p>
+            {% if article_link != nil %}
+            <!-- TODO: abstract out the folder reference -->
+            You can read the article <a href="{{ 'stack-2020/' | append: video.article_link}}">here</a>.
+            {% endif %}
+
+            {% if slide_link != nil %}
+              <a href="{{ '/assets/files/' | append: video.slide_link }}">
+                View Slides
+              </a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>

--- a/collections/_communities/events/stack-x-cloud-2021.html
+++ b/collections/_communities/events/stack-x-cloud-2021.html
@@ -3,248 +3,45 @@ title: STACK-X Cloud 2021
 layout: layout-page-sidenav
 description: >
  Stack-X Cloud is a one-day conference for developers and IT leaders to learn about the lates enhancements for GCC with practical lessons on cloud adoption
+video_list_layout: 'stack-x-cloud-2021-video-list.html'
 ---
 
-<style>
-  .speaker-list {
-    margin-top: 2rem;
-  }
-  .speaker-list > .row {
-    margin-bottom: 2rem;
-  }
-  .tab-content figure {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-  }
-  @media (max-width: 768px) {
-    .tab-content figure {
-      max-width: 33%;
-    }
-  }
-</style>
-
-<figure>
-  <img
-    src="/assets/img/STACK-X-Cloud-Banner01.jpg"
-    alt="Stack-X Cloud"
-  />
-</figure>
-
+<h2>STACK-X Cloud 2021</h2>
 <p>
-  <strong>Enhancements in GCC &bullet; Industry collaboration opportunities &bullet; Technical deep dives</strong>
+  Thank you for joining us at STACK X Cloud 2021. Missed any sessions? You can watch the video replays below
 </p>
-<p>
-  Join this virtual conference to learn how the Singapore
-  Government is accelerating digital transformation by
-  unlocking the power of Government on Commercial Cloud (GCC). 
-  Collaboration opportunities abound for all industry players. 
-  Hear from public sector practitioners & industry partners, covering topics like  
-  the cloud landscape and roadmap, latest GCC enhancements and practical
-  lessons on cloud adoption.
-</p>
-<p>
-<strong>
-    <a
-      class="sgds-button is-primary"
-      href="https://form.gov.sg/#!/615d7795d09a2900145c714f" target="_blank"
-      >Register Now</a
-    >
-  </strong>
-</p>
-
-<section>
-  <h4>Who should attend?</h4>
-  <p>We have tailored content for government agencies and industry partners:</p>
-  <div class="row is-multiline">
-    <div class="col is-6">
-     <ul>
-      <li type= "none">  
-       &ndash; Agency CIOs and IT Directors
-      </li>
-      <li type= "none">  
-       &ndash; Project Managers
-      <li type= "none">  
-       &ndash; Business Analysts
-      </li>
-      <li type= "none">  
-       &ndash; Developers
-      </li>
-      <li type= "none">  
-       &ndash; Solution Architects
-      </li>
-     </ul>
-    </div>
-<!--    <div class="col is-6">
-     <ul>
-      <li type= "none">  
-       &ndash; Industry Professionals
-      </li>
-     </ul>
-    </div> -->
-  </div>
-</section>
-<br />
-<figure>
-  <img
-    src="/assets/img/STACK-X-Cloud-Why-Should-You-Attend01.jpg"
-    alt="explanation on why we should attend Stack-X Cloud conference"
-  />
-</figure>
-
-<section class="col is-boxed">
-  <h4>Event details</h4>
-  <b>17 November 2021</b>
-  <p>Sessions:</p>
- <div class="row is-multiline">
-    <div class="col is-4">
-      <p>09:30 AM - 11:30 AM</p>
-    </div>
-    <div class="col is-8">
-      <p>Keynotes</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col is-4">
-      <p>1:30 PM - 3:30 PM</p>
-    </div>
-    <div class="col is-8">
-      <p>Tracks - Leadership, Cloud Onboarding, Cloud Platform & Tools</p>
-    </div>
-  </div>
-  <p>
-    Virtual sessions on Zoom
-  </p>
-</section>
-<br />
-<p>
-  <strong>
-    <a
-      class="sgds-button is-primary"
-      href="https://form.gov.sg/#!/615d7795d09a2900145c714f" target="_blank"
-      >Register Now</a
-    >
-  </strong>
-</p>
-<section>
-  <br />
-  <h4>Programme</h4>
-</section>
 
 <div class="sgds-tabs">
   <ul class="no-margin" role="tablist">
     <li class="is-active">
-      <a data-tab="#tab1" role="tab" aria-selected="true" aria-controls="tab1">
-        Keynotes
-      </a>
+        <a data-tab="#tab1" role="tab" aria-selected="true" aria-controls="tab1">
+          Keynotes
+        </a>
     </li>
     <li>
-      <a data-tab="#tab2" role="tab" aria-selected="false" aria-controls="tab2">
-        Leadership Track
-      </a>
+        <a data-tab="#tab2" role="tab" aria-selected="false" aria-controls="tab2">
+          Cloud Onboarding
+        </a>
     </li>
     <li>
-      <a data-tab="#tab3" role="tab" aria-selected="false" aria-controls="tab3">
-        Cloud Onboarding Track
-      </a>
+        <a data-tab="#tab3" role="tab" aria-selected="false" aria-controls="tab3">
+          Cloud Platform
+        </a>
     </li>
-    <li>
-      <a data-tab="#tab4" role="tab" aria-selected="false" aria-controls="tab4">
-        Cloud Platform & Tools Track
-      </a>
-    </li>
- <!--   <li>
-      <a data-tab="#tab5" role="tab" aria-selected="false" aria-controls="tab5">
-        Workshops
-      </a>
-    </li> -->
   </ul>
 </div>
-{% assign keynotes = site.data.stackx2021cloud | where_exp: "item", "item.type contains 'Keynote'" %}
-{% assign leaders = site.data.stackx2021cloud | where_exp: "item", "item.type contains 'Leader'" %}
-{% assign products = site.data.stackx2021cloud | where_exp: "item", "item.type contains 'Product'" %}
-{% assign governments = site.data.stackx2021cloud | where_exp: "item", "item.type contains 'Government'" %}
-
-<div class="tab-content" id="tab1">
-  <h6>Morning Keynotes</h6>
-  <p><strong>17 November 2021</strong></p>
-  <p>Virtual Conference: Zoom Webinar</p>
-  <p></p>
-  <p>
-    Thought leadership sessions for all – agencies, industry, leadership and
-    practitioners.
-  </p>  
-  {% include_relative includes/stack-x-cloud-2021-itinerary.html itinerary=keynotes %}
-  
+<div class="row" id="tab1">
+  {% if page.video_list_layout %}
+    {% include_relative {{ page.video_list_layout }} type="Keynote - VOD" %}
+  {% endif %}
 </div>
-
-<div class="tab-content" id="tab2">
-  <h6>Leadership Track</h6>
-  <p><strong>17 November 2021</strong></p>
-  <p>Virtual Conference: Zoom Meeting</p>
-  <p>
-    This is a closed virtual track curated for Agency CIOs and IT
-    Leaders to help them build and achieve a successful cloud strategy.
-  </p>
-  {% include_relative includes/stack-x-cloud-2021-itinerary.html itinerary=leaders %}
-
+<div class="row" id="tab2">
+  {% if page.video_list_layout %}
+    {% include_relative {{ page.video_list_layout }} type="CloudOnboarding - VOD" %}
+  {% endif %}
 </div>
-
-
-<div class="tab-content" id="tab3">
-  <h6>Cloud Onboarding Track</h6>
-  <p><strong>17 November 2021</strong></p>
-  <p>Virtual Conference: Zoom Webinar</p>
-  <p>
-    This virtual track is for Tech Leads, Project Managers, Business Analysts and 
-    Developers especially those looking to learn practical experience to onboard to cloud, 
-    including preparation for migration and day 2 operation. There is a live Q&A at the 
-    end of each session!
-  </p>
-  {% include_relative includes/stack-x-cloud-2021-itinerary.html itinerary=products %}
+<div class="row" id="tab3">
+  {% if page.video_list_layout %}
+  {% include_relative {{ page.video_list_layout }} type="CloudPlatform - VOD" %}
+{% endif %}
 </div>
-
-<div class="tab-content" id="tab4">
-  <h6>Cloud Platform & Tools Track</h6>
-  <p><strong>17 November 2021</strong></p>
-  <p>Virtual Conference: Zoom Webinar</p>
-  <p>
-    This virtual track is for developer communities, especially those who are looking
-    to understand Cloud Platform and Tools available within GCC. There is a live Q&A 
-    at the end of each session!
-  </p>
-
-  {% include_relative includes/stack-x-cloud-2021-itinerary.html itinerary=governments %}
-
-</div>
-<p></p>
-  <p>
-   <sub>* Please note that the programme may be subject to change without prior notice</sub>
-  </p><p></p>
-  <p>
-   Have a question? Drop us an email at <strong>STACKX2021@TWISTMEDIA.SG</strong>
-  </p>
-
-<!-- <div class="tab-content" id="tab5">
-  <h6>SHIP-HATS Developer Workshops</h6>
-   <p> Due to recent local Covid-19 developments, we are minimising social interaction. Hence, this session is <strong> postponed </strong>until further notice.</p>
-  
-  <p>
-    The workshop covers how to build and release a container application using
-    SHIP-HATS to Government Commercial Cloud (GCC)
-  </p>
-  <div class="sgds-card">
-    <div class="sgds-card-content">
-      <h4>Continuous Integration</h4>
-      <p>
-        Dependency management using Nexus solution and automated container
-        scanning using Prisma Cloud.
-      </p>
-      <h4>Release Management</h4>
-      <p>
-        Promote release artifacts to production with secure deployment to GCC
-        compartments.
-      </p>
-    </div>
-  </div>
-</div> -->

--- a/collections/_communities/events/stack-x-cloud-2021.html
+++ b/collections/_communities/events/stack-x-cloud-2021.html
@@ -20,12 +20,12 @@ video_list_layout: 'stack-x-cloud-2021-video-list.html'
     </li>
     <li>
         <a data-tab="#tab2" role="tab" aria-selected="false" aria-controls="tab2">
-          Cloud Onboarding
+          Cloud Onboarding Track
         </a>
     </li>
     <li>
         <a data-tab="#tab3" role="tab" aria-selected="false" aria-controls="tab3">
-          Cloud Platform
+          Cloud Platform & Tools Track
         </a>
     </li>
   </ul>


### PR DESCRIPTION
Changed the tab in  communities/events/stack-x-cloud-2021 to the video list below:
![image](https://user-images.githubusercontent.com/2618932/142966848-438e9999-d4ab-4046-99aa-47b581936ae4.png)
