### PR TITLE
Giving all agenda icon a more distinct name

### DIFF
--- a/apps/src/pages/AllSessionsApp.vue
+++ b/apps/src/pages/AllSessionsApp.vue
@@ -59,7 +59,7 @@
                 class="margin--bottom--none margin--left--none margin--right--sm"
               />
               {{ option.category.type }}
-              <span class="icon icon--checkLight" style="align-items: center">
+              <span class="pilllist-icon pilllist-icon--checkLight" style="align-items: center">
                 <i
                   class="sgds-icon sgds-icon-check margin--bottom--none is-size-7"
                   role="img"

--- a/apps/src/sass/components/_pillboxes.scss
+++ b/apps/src/sass/components/_pillboxes.scss
@@ -35,21 +35,21 @@
   text-decoration: none;
 }
 
-.pilllist-item input[type="checkbox"]:checked+.pilllist-label .icon--checkLight {
+.pilllist-item input[type="checkbox"]:checked+.pilllist-label .pilllist-icon--checkLight {
   display: flex;
 }
 
-.pilllist-item input[type="checkbox"]:checked+.pilllist-label .icon--addLight,
-.pilllist-label .icon--checkLight,
+.pilllist-item input[type="checkbox"]:checked+.pilllist-label .pilllist-icon--addLight,
+.pilllist-label .pilllist-icon--checkLight,
 .pilllist-children {
   display: none;
 }
 
-.pilllist-label .icon {
+.pilllist-label .pilllist-icon {
   margin: 0 0 0 6px;
 }
 
-.icon {
+.pilllist-icon {
   background: transparent;
   display: inline-block;
   font-style: normal;


### PR DESCRIPTION
# Introduction
The all agenda classname, icon was too generic. As a result, it may have overridden the default sgds iconography.