### PR TITLE
Remove readme from build folder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ exclude:
   - netlify.toml
   - package*.json
   - webpack.config.js
+  - README.md
 
 collections_dir: collections
 


### PR DESCRIPTION
Changelog
---
1. Removing README.md from build folder as it is not necessary
![image](https://user-images.githubusercontent.com/2618932/180120758-31391bd0-392c-4de3-bc5b-adc56dd2acc1.png)

https://www.developer.tech.gov.sg/README.md

Expected https://pr-1357.d2ox9xl4t2suu6.amplifyapp.com/404.html when user goes to https://pr-1357.d2ox9xl4t2suu6.amplifyapp.com/README.md
