### PR TITLE
Grammatical amendments to the events / community section

### DIFF
--- a/_includes/card-variant-calendar.html
+++ b/_includes/card-variant-calendar.html
@@ -53,7 +53,7 @@
             class="is-hidden-touch has-text-weight-semibold padding--left padding--right margin--bottom margin--top padding--top--xs padding--bottom--xs is-size-8"
             style="background-color: #CCE4F7; width: fit-content; border-radius: 0.1rem; border-radius: .25rem;"
             data-recording-available="true">
-            Recordings available
+            Recording available
           </div>
           {%- endif -%}
           <!-- Category Slot -->

--- a/apps/src/communities/layout-page-sidenav-calendar.js
+++ b/apps/src/communities/layout-page-sidenav-calendar.js
@@ -63,7 +63,7 @@ import {
           case status === "past":
             if (recordingLink) {
               eventInformationAnchorTag.href = recordingLink;
-              eventInformationAnchorTag.textContent = "View Recording";
+              eventInformationAnchorTag.textContent = "View Recordings";
               eventInformationAnchorTag.style.backgroundColor = "#0161AF";
               break;
             }

--- a/apps/src/search/SearchAllEvents.vue
+++ b/apps/src/search/SearchAllEvents.vue
@@ -125,7 +125,7 @@
                   border-radius: 0.25rem;
                 "
               >
-                Recordings available
+                Recording available
               </div>
             </template>
             <!-- Category Slot-->


### PR DESCRIPTION
1. All conferences listed under the conferences overview page (https://www.developer.tech.gov.sg/communities/events/conferences/) should have the “View Recording” button to be amended to “View Recordings”

![image](https://user-images.githubusercontent.com/58126222/223366468-b5e3d652-7c16-4f4f-a393-75b065ec944b.png)


2. All meetup pages listed under the meetup overview page (https://www.developer.tech.gov.sg/communities/events/stack-meetups/) to amend the “ Recordings available” sign to be amended to “Recording available” 

![image](https://user-images.githubusercontent.com/58126222/223366352-6953d602-dbcf-4d0e-a917-c41f68db21f6.png)

